### PR TITLE
fix : findAll 삭제 및 이메일 비밀번호로 찾기 수정

### DIFF
--- a/src/main/java/com/uniqueauction/domain/login/service/LoginService.java
+++ b/src/main/java/com/uniqueauction/domain/login/service/LoginService.java
@@ -1,5 +1,7 @@
 package com.uniqueauction.domain.login.service;
 
+import static com.uniqueauction.exception.ErrorCode.*;
+
 import javax.servlet.http.HttpSession;
 
 import org.springframework.stereotype.Service;
@@ -8,6 +10,7 @@ import com.uniqueauction.domain.user.entity.Role;
 import com.uniqueauction.domain.user.entity.User;
 import com.uniqueauction.domain.user.repository.UserRepository;
 import com.uniqueauction.domain.user.service.EncryptService;
+import com.uniqueauction.exception.advice.CommonNotFoundException;
 import com.uniqueauction.web.login.request.LoginRequest;
 
 import lombok.RequiredArgsConstructor;
@@ -22,9 +25,10 @@ public class LoginService {
 
 	public void login(LoginRequest loginRequest) {
 
-		User byEmailAndPassword = userRepository.findByEmailAndEncodedPassword(loginRequest.getEmail(),
-			encryptService.encrypt(loginRequest.getPassword()));
+		User user = userRepository.findByEmailAndEncodedPassword(
+				loginRequest.getEmail(), encryptService.encrypt(loginRequest.getPassword()))
+			.orElseThrow(() -> new CommonNotFoundException(NOT_FOUND_USER));
 
-		Role.setSession(session, byEmailAndPassword);
+		Role.setSession(session, user);
 	}
 }

--- a/src/main/java/com/uniqueauction/domain/login/service/LoginService.java
+++ b/src/main/java/com/uniqueauction/domain/login/service/LoginService.java
@@ -1,9 +1,5 @@
 package com.uniqueauction.domain.login.service;
 
-import static com.uniqueauction.exception.ErrorCode.*;
-
-import java.util.List;
-
 import javax.servlet.http.HttpSession;
 
 import org.springframework.stereotype.Service;
@@ -12,7 +8,6 @@ import com.uniqueauction.domain.user.entity.Role;
 import com.uniqueauction.domain.user.entity.User;
 import com.uniqueauction.domain.user.repository.UserRepository;
 import com.uniqueauction.domain.user.service.EncryptService;
-import com.uniqueauction.exception.advice.CommonNotFoundException;
 import com.uniqueauction.web.login.request.LoginRequest;
 
 import lombok.RequiredArgsConstructor;
@@ -27,14 +22,9 @@ public class LoginService {
 
 	public void login(LoginRequest loginRequest) {
 
-		List<User> users = userRepository.findAll();
+		User byEmailAndPassword = userRepository.findByEmailAndEncodedPassword(loginRequest.getEmail(),
+			encryptService.encrypt(loginRequest.getPassword()));
 
-		User findUser = users.stream()
-			.filter(user -> user.getEmail().equals(loginRequest.getEmail())
-				&& user.getEncodedPassword().equals(encryptService.encrypt(loginRequest.getPassword())))
-			.findFirst()
-			.orElseThrow(() -> new CommonNotFoundException(NOT_FOUND_USER));
-
-		Role.setSession(session, findUser);
+		Role.setSession(session, byEmailAndPassword);
 	}
 }

--- a/src/main/java/com/uniqueauction/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/uniqueauction/domain/user/repository/UserRepository.java
@@ -8,4 +8,6 @@ import com.uniqueauction.domain.user.entity.User;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 	boolean existsByEmail(String email);
+
+	User findByEmailAndEncodedPassword(String email, String encrypt);
 }

--- a/src/main/java/com/uniqueauction/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/uniqueauction/domain/user/repository/UserRepository.java
@@ -1,5 +1,7 @@
 package com.uniqueauction.domain.user.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,5 +11,5 @@ import com.uniqueauction.domain.user.entity.User;
 public interface UserRepository extends JpaRepository<User, Long> {
 	boolean existsByEmail(String email);
 
-	User findByEmailAndEncodedPassword(String email, String encrypt);
+	Optional<User> findByEmailAndEncodedPassword(String email, String encrypt);
 }

--- a/src/test/java/com/uniqueauction/TestContainerBase.java
+++ b/src/test/java/com/uniqueauction/TestContainerBase.java
@@ -6,9 +6,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.test.context.ActiveProfiles;
 
 /** 통합 테스트시 외부 요인으로인해 기대하던 데이터를 받지못해 테스트 실패하는경우 발생.
@@ -22,8 +19,5 @@ import org.springframework.test.context.ActiveProfiles;
 @Target(ElementType.TYPE)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@AutoConfigureMockMvc
-@EnableAspectJAutoProxy
-@SpringBootTest
 public @interface TestContainerBase {
 }

--- a/src/test/java/com/uniqueauction/domain/login/LoginServiceTest.java
+++ b/src/test/java/com/uniqueauction/domain/login/LoginServiceTest.java
@@ -4,17 +4,18 @@ import static com.uniqueauction.domain.user.entity.Role.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.servlet.http.HttpSession;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
 
 import com.uniqueauction.AbstractContainerBaseTest;
 import com.uniqueauction.TestContainerBase;
@@ -26,6 +27,7 @@ import com.uniqueauction.exception.advice.CommonNotFoundException;
 import com.uniqueauction.web.login.request.LoginRequest;
 
 @TestContainerBase
+@ExtendWith(MockitoExtension.class) //  Mockito를 사용하려면 붙여줘야되 어느테이션
 public class LoginServiceTest extends AbstractContainerBaseTest {
 
 	@Spy
@@ -35,23 +37,36 @@ public class LoginServiceTest extends AbstractContainerBaseTest {
 	@Mock
 	private EncryptService encryptService;
 
-	@Mock
-	private HttpSession session;
+	protected MockHttpSession session;
+	protected MockHttpServletRequest request;
 
 	@Mock
 	private UserRepository userRepository;
 
 	@BeforeEach
 	public void set() {
-		session = mock(HttpSession.class);
+
+		session = new MockHttpSession();
+		session.setAttribute("MEMBER_USER", 1);
+
+		//
+		request = new MockHttpServletRequest();
+		request.setSession(session);
+
+		loginService = new LoginService(userRepository, session, encryptService);
+		// RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 	}
 
 	@Test
 	@DisplayName("로그인 성공시 예외가발생하지 않는다")
 	void loginServiceSuccess() {
 
-		doReturn(anyUser(getLoginRequest())).when(userRepository).findAll();
 		doReturn("@@@@@@@@@@").when(encryptService).encrypt(getLoginRequest().getPassword());
+
+		User user = getUser();
+
+		doReturn(Optional.ofNullable(user)).when(userRepository)
+			.findByEmailAndEncodedPassword(getLoginRequest().getEmail(), getLoginRequest().getPassword());
 
 		loginService.login(getLoginRequest());
 
@@ -61,9 +76,6 @@ public class LoginServiceTest extends AbstractContainerBaseTest {
 	@DisplayName("로그인 실패시(계정이없는경우) 예외 출력")
 	void loginServiceFail() {
 
-		doReturn(anyUser(getLoginRequest())).when(userRepository).findAll();
-		doReturn("@@@@@@@@@@").when(encryptService).encrypt(getNotUserRequest().getPassword());
-
 		assertThatThrownBy(
 			() ->
 				loginService.login(getNotUserRequest())
@@ -71,24 +83,17 @@ public class LoginServiceTest extends AbstractContainerBaseTest {
 
 	}
 
-	private List<User> anyUser(LoginRequest loginRequest) {
-		List<User> list = new ArrayList<>();
-		list.add(getUser(loginRequest));
-		list.get(0).setId(1L);
-		return list;
-	}
-
-	private User getUser(LoginRequest loginRequest) {
+	private User getUser() {
 		return User.builder()
 			.email("email@email.com")
 			.encodedPassword("@@@@@@@@@@")
 			.phone("010-1234-1344")
-			.role(ADMIN)
+			.role(CUSTOMER)
 			.build();
 	}
 
 	private LoginRequest getLoginRequest() {
-		return new LoginRequest("email@email.com", "123");
+		return new LoginRequest("email@email.com", "@@@@@@@@@@");
 	}
 
 	private LoginRequest getNotUserRequest() {

--- a/src/test/java/com/uniqueauction/domain/product/repository/ProductRepositoryImplTest.java
+++ b/src/test/java/com/uniqueauction/domain/product/repository/ProductRepositoryImplTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
 import com.uniqueauction.AbstractContainerBaseTest;
 import com.uniqueauction.TestContainerBase;
@@ -18,6 +19,7 @@ import com.uniqueauction.web.product.request.ProductSaveRequest;
 import com.uniqueauction.web.product.request.ProductUpdateRequest;
 
 @TestContainerBase
+@SpringBootTest
 class ProductRepositoryImplTest extends AbstractContainerBaseTest {
 
 	@Autowired

--- a/src/test/java/com/uniqueauction/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/uniqueauction/domain/product/service/ProductServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
+import org.springframework.boot.test.context.SpringBootTest;
 
 import com.uniqueauction.AbstractContainerBaseTest;
 import com.uniqueauction.TestContainerBase;
@@ -31,6 +32,7 @@ import com.uniqueauction.web.product.request.ProductUpdateRequest;
  * @InjectMocks: @Mock 또는 @Spy로 생성된 가짜 객체를 자동으로 주입시켜주는 어노테이션
  */
 @TestContainerBase
+@SpringBootTest
 class ProductServiceTest extends AbstractContainerBaseTest {
 
 	@Spy

--- a/src/test/java/com/uniqueauction/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/uniqueauction/domain/user/service/UserServiceTest.java
@@ -2,11 +2,13 @@ package com.uniqueauction.domain.user.service;
 
 import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
 import com.uniqueauction.AbstractContainerBaseTest;
 import com.uniqueauction.TestContainerBase;
 
 @TestContainerBase
+@SpringBootTest
 class UserServiceTest extends AbstractContainerBaseTest {
 
 	@Autowired

--- a/src/test/java/com/uniqueauction/web/login/controller/LoginControllerTest.java
+++ b/src/test/java/com/uniqueauction/web/login/controller/LoginControllerTest.java
@@ -6,6 +6,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -31,6 +33,8 @@ import com.uniqueauction.web.login.request.LoginRequest;
  * Car carObject = mapper.readValue(text, Car.class); //Car{name='k5',color='gary
  */
 @EnableAutoConfiguration
+@AutoConfigureMockMvc
+@SpringBootTest
 @TestContainerBase
 class LoginControllerTest extends AbstractContainerBaseTest {
 

--- a/src/test/java/com/uniqueauction/web/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/uniqueauction/web/product/controller/ProductControllerTest.java
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -21,8 +24,11 @@ import com.uniqueauction.domain.product.service.ProductService;
 import com.uniqueauction.web.product.request.ProductSaveRequest;
 import com.uniqueauction.web.product.request.ProductUpdateRequest;
 
-@ExtendWith(SpringExtension.class)
 @TestContainerBase
+@ExtendWith(SpringExtension.class)
+@EnableAutoConfiguration
+@AutoConfigureMockMvc
+@SpringBootTest
 class ProductControllerTest extends AbstractContainerBaseTest {
 
 	@Autowired

--- a/src/test/java/com/uniqueauction/web/user/controller/UserControllerTest.java
+++ b/src/test/java/com/uniqueauction/web/user/controller/UserControllerTest.java
@@ -6,9 +6,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,6 +24,10 @@ import com.uniqueauction.web.user.request.JoinRequest;
 import com.uniqueauction.web.user.request.UpdateUserRequest;
 
 @TestContainerBase
+@ExtendWith(SpringExtension.class)
+@EnableAutoConfiguration
+@AutoConfigureMockMvc
+@SpringBootTest
 class UserControllerTest extends AbstractContainerBaseTest {
 
 	@MockBean


### PR DESCRIPTION
**관련된 이슈 번호**
- issue : #76


**요약**
- 로그인시 findAll 대신 이메일 비밀번호로 로그인하게.

