### PR TITLE
Fix : 테스트 리팩토링 및 로그인 서비스 리팩토링

### DIFF
--- a/src/main/java/com/uniqueauction/domain/login/service/LoginService.java
+++ b/src/main/java/com/uniqueauction/domain/login/service/LoginService.java
@@ -6,12 +6,12 @@ import javax.servlet.http.HttpSession;
 
 import org.springframework.stereotype.Service;
 
-import com.uniqueauction.domain.user.entity.Role;
 import com.uniqueauction.domain.user.entity.User;
 import com.uniqueauction.domain.user.repository.UserRepository;
 import com.uniqueauction.domain.user.service.EncryptService;
 import com.uniqueauction.exception.advice.CommonNotFoundException;
 import com.uniqueauction.web.login.request.LoginRequest;
+import com.utils.SessionUtil;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,6 +29,6 @@ public class LoginService {
 				loginRequest.getEmail(), encryptService.encrypt(loginRequest.getPassword()))
 			.orElseThrow(() -> new CommonNotFoundException(NOT_FOUND_USER));
 
-		Role.setSession(session, user);
+		SessionUtil.setSession(session, user);
 	}
 }

--- a/src/main/java/com/utils/SessionUtil.java
+++ b/src/main/java/com/utils/SessionUtil.java
@@ -1,6 +1,10 @@
 package com.utils;
 
+import static com.uniqueauction.domain.user.entity.Role.*;
+
 import javax.servlet.http.HttpSession;
+
+import com.uniqueauction.domain.user.entity.User;
 
 public class SessionUtil {
 
@@ -55,5 +59,13 @@ public class SessionUtil {
 	 */
 	public static void clear(HttpSession session) {
 		session.invalidate();
+	}
+
+	public static void setSession(HttpSession session, User user) {
+		if (user.getRole() == ADMIN) {
+			SessionUtil.setLoginAdminId(session, user.getId());
+		} else {
+			SessionUtil.setLoginMemberId(session, user.getId());
+		}
 	}
 }

--- a/src/test/java/com/uniqueauction/domain/login/LoginServiceTest.java
+++ b/src/test/java/com/uniqueauction/domain/login/LoginServiceTest.java
@@ -51,14 +51,13 @@ public class LoginServiceTest {
 		request.setSession(session);
 
 		loginService = new LoginService(userRepository, session, encryptService);
-		// RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 	}
 
 	@Test
 	@DisplayName("로그인 성공시 예외가발생하지 않는다")
 	void loginServiceSuccess() {
 
-		doReturn("@@@@@@@@@@").when(encryptService).encrypt(getLoginRequest().getPassword());
+		doReturn("@@@@@@@@@@").when(encryptService).encrypt(anyString());
 
 		User user = getUser();
 
@@ -73,9 +72,14 @@ public class LoginServiceTest {
 	@DisplayName("로그인 실패시(계정이없는경우) 예외 출력")
 	void loginServiceFail() {
 
+		doReturn("@@@@@@@@@@").when(encryptService).encrypt(anyString());
+
+		doReturn(Optional.empty()).when(userRepository)
+			.findByEmailAndEncodedPassword(anyString(), anyString());
+
 		assertThatThrownBy(
 			() ->
-				loginService.login(getNotUserRequest())
+				loginService.login(getLoginRequest())
 		).isInstanceOf(CommonNotFoundException.class);
 
 	}

--- a/src/test/java/com/uniqueauction/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/uniqueauction/domain/product/service/ProductServiceTest.java
@@ -1,11 +1,10 @@
 package com.uniqueauction.domain.product.service;
 
+import static com.uniqueauction.CommonUtilMethod.*;
 import static com.uniqueauction.domain.product.entity.Category.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +41,7 @@ class ProductServiceTest {
 
 	private Product saveProduct;
 	private Product updateProduct;
-	private Long pId = 1L;
+	private Long pId = getRandomLong();
 
 	@BeforeEach
 	public void set() {
@@ -73,8 +72,6 @@ class ProductServiceTest {
 	@Test
 	void productDetailSelectTest() {
 
-		Long pId = 1L;
-
 		//given
 		doReturn(Optional.of(getSaveProduct())).when(productRepository).findById(pId);
 		//when
@@ -91,8 +88,6 @@ class ProductServiceTest {
 
 	@Test
 	void productUpdateTest() {
-
-		Long pId = 1L;
 
 		//given
 		doReturn(updateProduct).when(productService).update(updateProduct);
@@ -157,11 +152,4 @@ class ProductServiceTest {
 			.imgUrl("/test/test")
 			.build();
 	}
-
-	public List<Product> getListProduct(ProductSaveRequest saveProduct) {
-		List<Product> list = new ArrayList<>();
-		list.add(saveProduct.toEntity());
-		return list;
-	}
-
 }

--- a/src/test/java/com/uniqueauction/domain/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/uniqueauction/domain/review/repository/ReviewRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.uniqueauction.domain.review.repository;
 
+import static com.uniqueauction.CommonUtilMethod.*;
 import static com.uniqueauction.domain.product.entity.Category.*;
 import static com.uniqueauction.domain.user.entity.Role.*;
 import static org.assertj.core.api.Assertions.*;
@@ -83,7 +84,6 @@ class ReviewRepositoryTest extends AbstractContainerBaseTest {
 
 	private User getUser() {
 		return User.builder()
-			// .id(commonId)
 			.email("test@test.com")
 			.username("test")
 			.encodedPassword("1234Aa1234")
@@ -94,7 +94,6 @@ class ReviewRepositoryTest extends AbstractContainerBaseTest {
 
 	private Product getProduct() {
 		return Product.builder()
-			// .id(commonId)
 			.name("상품1")
 			.modelNumber("1234")
 			.releasePrice("10000")
@@ -106,8 +105,8 @@ class ReviewRepositoryTest extends AbstractContainerBaseTest {
 
 	private SaveReviewRequest createSaveReviewsReq() {
 		return SaveReviewRequest.builder()
-			.userId(1L)
-			.productId(1L)
+			.userId(getRandomLong())
+			.productId(getRandomLong())
 			.score(3)
 			.content("test")
 			.build();

--- a/src/test/java/com/uniqueauction/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/uniqueauction/domain/review/service/ReviewServiceTest.java
@@ -1,5 +1,6 @@
 package com.uniqueauction.domain.review.service;
 
+import static com.uniqueauction.CommonUtilMethod.*;
 import static com.uniqueauction.domain.product.entity.Category.*;
 import static com.uniqueauction.domain.user.entity.Role.*;
 import static org.assertj.core.api.Assertions.*;
@@ -21,7 +22,6 @@ import com.uniqueauction.domain.review.entity.Review;
 import com.uniqueauction.domain.review.repository.ReviewRepository;
 import com.uniqueauction.domain.user.entity.User;
 import com.uniqueauction.event.ReviewEventPublisher;
-import com.uniqueauction.exception.advice.CommonNotFoundException;
 import com.uniqueauction.web.review.request.SaveReviewRequest;
 import com.uniqueauction.web.review.response.ReviewByProductResponse;
 import com.uniqueauction.web.review.response.ReviewByUserResponse;
@@ -30,7 +30,7 @@ import com.uniqueauction.web.review.response.ReviewInfo;
 @ExtendWith(MockitoExtension.class) // 클래스단에 해당 어노테이션을 달아, 클래스가 Mockito를 사용함을 명시적으로 알립니다.
 class ReviewServiceTest {
 
-	private static final Long commonId = 1L;
+	private static final Long DUMY = getRandomLong();
 
 	@InjectMocks
 	ReviewService reviewService;
@@ -54,8 +54,6 @@ class ReviewServiceTest {
 		doReturn(getUser()).when(reviewEventPublisher).getUser(any(Long.class));
 		doReturn(getProduct()).when(reviewEventPublisher).getProduct(any(Long.class));
 		doReturn(getReview()).when(reviewRepository).save(any(Review.class));
-
-		// doReturn(getReview()).when(reviewRepository).save(getReview()); 왜 null이 나올까?
 
 		//when
 		Review review = reviewService.save(createSaveReviewsReq());
@@ -97,38 +95,10 @@ class ReviewServiceTest {
 		assertThat(byUserId.getReviews().size()).isEqualTo(5);
 	}
 
-	@Test
-	@DisplayName("상품이 없을땐 NOTFOUND EXCEPTION")
-	void emptyProductNotFoundTest() {
-
-		//when
-		doThrow(CommonNotFoundException.class).when(reviewEventPublisher).getProduct(any(Long.class));
-		//then
-
-		assertThatThrownBy(
-			() -> reviewService.save(createSaveReviewsReq())
-		).isInstanceOf(CommonNotFoundException.class);
-
-	}
-
-	@Test
-	@DisplayName("유저이 없을땐 NOTFOUND EXCEPTION")
-	void emptyUserNotFoundTest() {
-
-		//when
-		doThrow(CommonNotFoundException.class).when(reviewEventPublisher).getUser(any(Long.class));
-		//then
-
-		assertThatThrownBy(
-			() -> reviewService.save(createSaveReviewsReq())
-		).isInstanceOf(CommonNotFoundException.class);
-
-	}
-
 	private SaveReviewRequest createSaveReviewsReq() {
 		return SaveReviewRequest.builder()
-			.userId(1L)
-			.productId(1L)
+			.userId(DUMY)
+			.productId(DUMY)
 			.score(3)
 			.content("test")
 			.build();
@@ -136,7 +106,7 @@ class ReviewServiceTest {
 
 	private User getUser() {
 		return User.builder()
-			.id(commonId)
+			.id(DUMY)
 			.email("test@test.com")
 			.username("test")
 			.encodedPassword("1234Aa1234")
@@ -147,7 +117,7 @@ class ReviewServiceTest {
 
 	private Product getProduct() {
 		return Product.builder()
-			.id(commonId)
+			.id(DUMY)
 			.name("상품1")
 			.modelNumber("1234")
 			.releasePrice("10000")

--- a/src/test/java/com/uniqueauction/web/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/uniqueauction/web/product/controller/ProductControllerTest.java
@@ -1,5 +1,6 @@
 package com.uniqueauction.web.product.controller;
 
+import static com.uniqueauction.CommonUtilMethod.*;
 import static com.uniqueauction.domain.product.entity.Category.*;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.any;
@@ -17,7 +18,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.uniqueauction.TestContainerBase;
 import com.uniqueauction.domain.product.service.ProductService;
 import com.uniqueauction.web.product.request.ProductSaveRequest;
 import com.uniqueauction.web.product.request.ProductUpdateRequest;
@@ -76,14 +76,13 @@ class ProductControllerTest {
 	@Test
 	@DisplayName("상품 삭제  완료가 되면 status  200을 반환한다.")
 	void productDeleteTest() throws Exception {
-		Long id = 1L;
 
 		mockMvc.perform(
 				delete("/products/" + 1)
 					.contentType(MediaType.APPLICATION_JSON)
 					.accept(MediaType.APPLICATION_JSON)
 					.characterEncoding("UTF-8")
-					.content(String.valueOf(id)))
+					.content(String.valueOf(getRandomLong())))
 			.andExpect(status().isOk());
 
 	}
@@ -91,14 +90,13 @@ class ProductControllerTest {
 	@Test
 	@DisplayName("상품 상세  완료가 되면 status  200을 반환한다.")
 	void productDetailSelectTest() throws Exception {
-		Long id = 1L;
 
 		mockMvc.perform(
 				get("/products/" + 1)
 					.contentType(MediaType.APPLICATION_JSON)
 					.accept(MediaType.APPLICATION_JSON)
 					.characterEncoding("UTF-8")
-					.content(String.valueOf(id)))
+					.content(String.valueOf(getRandomLong())))
 			.andExpect(status().isOk());
 
 	}
@@ -141,7 +139,7 @@ class ProductControllerTest {
 
 	private ProductUpdateRequest updateProduct() {
 		return ProductUpdateRequest.builder()
-			.productId(1L)
+			.productId(getRandomLong())
 			.productName("상품2")
 			.modelNumber("1")
 			.releasePrice("10000")

--- a/src/test/java/com/uniqueauction/web/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/uniqueauction/web/review/controller/ReviewControllerTest.java
@@ -1,5 +1,6 @@
 package com.uniqueauction.web.review.controller;
 
+import static com.uniqueauction.CommonUtilMethod.*;
 import static com.uniqueauction.domain.product.entity.Category.*;
 import static com.uniqueauction.domain.user.entity.Role.*;
 import static org.hamcrest.Matchers.*;
@@ -23,7 +24,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.uniqueauction.TestContainerBase;
 import com.uniqueauction.domain.product.entity.Product;
 import com.uniqueauction.domain.review.entity.Review;
 import com.uniqueauction.domain.review.service.ReviewService;
@@ -95,7 +95,7 @@ class ReviewControllerTest {
 	@DisplayName("프로덕트 ID로 리뷰 목록들을 조회한다.")
 	void selectProductReviws() throws Exception {
 
-		doReturn(findByPidRes()).when(reviewService).findByProductId(1L);
+		doReturn(findByPidRes()).when(reviewService).findByProductId(anyLong());
 
 		mockMvc.perform(get("/reviews/1/products")
 				.accept(MediaType.APPLICATION_JSON))
@@ -114,7 +114,7 @@ class ReviewControllerTest {
 	@DisplayName("유저 ID로 리뷰 목록들을 조회한다.")
 	void selectUserReviws() throws Exception {
 
-		doReturn(findByUidRes()).when(reviewService).findByUserId(1L);
+		doReturn(findByUidRes()).when(reviewService).findByUserId(anyLong());
 
 		mockMvc.perform(get("/reviews/1/users")
 				.accept(MediaType.APPLICATION_JSON))
@@ -129,8 +129,8 @@ class ReviewControllerTest {
 
 	private SaveReviewRequest createSaveReviewsReq() {
 		return SaveReviewRequest.builder()
-			.userId(1L)
-			.productId(1L)
+			.userId(getRandomLong())
+			.productId(getRandomLong())
 			.score(3)
 			.content("test")
 			.build();
@@ -138,8 +138,8 @@ class ReviewControllerTest {
 
 	private SaveReviewRequest overFiveScoreSaveReviewsReq() {
 		return SaveReviewRequest.builder()
-			.userId(1L)
-			.productId(1L)
+			.userId(getRandomLong())
+			.productId(getRandomLong())
 			.score(6)
 			.content("test")
 			.build();
@@ -147,8 +147,8 @@ class ReviewControllerTest {
 
 	private SaveReviewRequest underOneScoreSaveReviewsReq() {
 		return SaveReviewRequest.builder()
-			.userId(1L)
-			.productId(1L)
+			.userId(getRandomLong())
+			.productId(getRandomLong())
 			.score(0)
 			.content("test")
 			.build();
@@ -184,7 +184,7 @@ class ReviewControllerTest {
 
 	private User getUser() {
 		return User.builder()
-			.id(1L)
+			.id(getRandomLong())
 			.email("test@test.com")
 			.username("test")
 			.encodedPassword("1234Aa1234")
@@ -195,7 +195,7 @@ class ReviewControllerTest {
 
 	private Product getProduct() {
 		return Product.builder()
-			.id(1L)
+			.id(getRandomLong())
 			.name("상품1")
 			.modelNumber("1234")
 			.releasePrice("10000")

--- a/src/test/java/com/uniqueauction/web/trade/controller/PurchaseControllerTest.java
+++ b/src/test/java/com/uniqueauction/web/trade/controller/PurchaseControllerTest.java
@@ -24,6 +24,8 @@ import com.uniqueauction.web.trade.request.PurchaseRequest;
 @AutoConfigureMockMvc
 class PurchaseControllerTest {
 
+	private static final Long DUMY = getRandomLong();
+
 	@Autowired
 	private MockMvc mockMvc;
 
@@ -36,7 +38,7 @@ class PurchaseControllerTest {
 	@DisplayName("구매입찰 정상 테스트 201 반환")
 	void purchaseCreateTest() throws Exception {
 
-		doReturn(1L).when(purchaseService).savePurchase(any());
+		doReturn(DUMY).when(purchaseService).savePurchase(any());
 
 		mockMvc.perform(
 				post("/purchase")
@@ -45,7 +47,7 @@ class PurchaseControllerTest {
 					.characterEncoding("UTF-8")
 					.content(objectMapper.writeValueAsString(getPurchaseReq())))
 			.andExpect(status().isCreated())
-			.andExpect(jsonPath("data", is(1)));
+			.andExpect(jsonPath("data", is(DUMY)));
 	}
 
 	@Test

--- a/src/test/java/com/uniqueauction/web/trade/controller/SaleControllerTest.java
+++ b/src/test/java/com/uniqueauction/web/trade/controller/SaleControllerTest.java
@@ -24,6 +24,8 @@ import com.uniqueauction.web.trade.request.SaleRequest;
 @AutoConfigureMockMvc
 class SaleControllerTest {
 
+	private static final Long DUMY = getRandomLong();
+
 	@Autowired
 	private MockMvc mockMvc;
 
@@ -36,7 +38,7 @@ class SaleControllerTest {
 	@DisplayName("판매입찰 정상 테스트 201 반환 ")
 	void saleCreateTest() throws Exception {
 
-		doReturn(1L).when(saleService).saveSale(any());
+		doReturn(DUMY).when(saleService).saveSale(any());
 
 		mockMvc.perform(
 				post("/sale")
@@ -45,7 +47,7 @@ class SaleControllerTest {
 					.characterEncoding("UTF-8")
 					.content(objectMapper.writeValueAsString(getSaleReq())))
 			.andExpect(status().isCreated())
-			.andExpect(jsonPath("data", is(1)));
+			.andExpect(jsonPath("data", is(DUMY)));
 
 	}
 


### PR DESCRIPTION
**관련된 이슈 번호**
- issue : #94


**요약**
- 테스트 공통적으로 명시적 1L 사용대신 DUMY 로 쓸모없는 데이터라는걸 명시 하거나 랜덤으로 Long값을 줘서 어떤 값이든 테스트 통과
- 협력 객체 테스트 에 추가

